### PR TITLE
FEAT: generate API with simple configuration value

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,11 +1,5 @@
 {
   "version": "0.2",
-  "enableFiletypes": [
-    "git-commit",
-    "github-actions-workflow",
-    "julia",
-    "jupyter"
-  ],
   "flagWords": [
     "analyse",
     "colour",
@@ -20,6 +14,7 @@
     "transisions"
   ],
   "ignorePaths": [
+    "**/*.rst_t",
     "**/.cspell.json",
     ".editorconfig",
     ".gitignore",
@@ -30,6 +25,8 @@
   ],
   "language": "en-US",
   "words": [
+    "ampform",
+    "apidoc",
     "autoapi",
     "autodoc",
     "ComPWA",
@@ -46,6 +43,14 @@
     "refspecific",
     "reftarget",
     "reftype",
-    "rtfd"
+    "rtfd",
+    "srcdir",
+    "templatedir"
+  ],
+  "enableFiletypes": [
+    "git-commit",
+    "github-actions-workflow",
+    "julia",
+    "jupyter"
   ]
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
       - id: blacken-docs
 
   - repo: https://github.com/ComPWA/repo-maintenance
-    rev: 0.1.6
+    rev: 0.1.7
     hooks:
       - id: check-dev-files
         args:

--- a/README.md
+++ b/README.md
@@ -48,3 +48,24 @@ api_target_types: dict[str, str] = {
     "RangeDefinition": "obj",
 }
 ```
+
+## Generate API
+
+To generate the API for [`sphinx.ext.autodoc`](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html), add this to your `conf.py`:
+
+```python
+api_package_path = "../src/my_package"  # relative to conf.py
+```
+
+The API is generated with the same style used by the ComPWA repositories (see e.g. [ampform.rtfd.io/en/stable/api/ampform.html](https://ampform.readthedocs.io/en/stable/api/ampform.html)). To use the default template, set:
+
+```python
+generate_apidoc_use_compwa_template = False
+```
+
+Other configuration values (with their defaults):
+
+```python
+generate_apidoc_directory = "api"
+generate_apidoc_excludes = ["version.py"]
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,10 @@ license-files = ["LICENSE"]
 package-dir = {"" = "src"}
 
 [tool.setuptools.package-data]
-"*" = ["py.typed"]
+"*" = [
+    "py.typed",
+    "templates/*.rst_t",
+]
 
 [tool.setuptools.packages.find]
 namespaces = false

--- a/src/sphinx_api_relink/templates/module.rst_t
+++ b/src/sphinx_api_relink/templates/module.rst_t
@@ -1,0 +1,12 @@
+{%- if show_headings and not separate %}
+{{ basename.split(".")[-1] | e | heading }}
+
+.. code-block:: python
+
+  import {{ basename }}
+
+{% endif -%}
+.. automodule:: {{ qualname }}
+{%- for option in automodule_options %}
+  :{{ option }}:
+{%- endfor %}

--- a/src/sphinx_api_relink/templates/package.rst_t
+++ b/src/sphinx_api_relink/templates/package.rst_t
@@ -1,0 +1,49 @@
+{%- macro automodule(modname, options) -%}
+.. automodule:: {{ modname }}
+{%- for option in options %}
+  :{{ option }}:
+{%- endfor %}
+{%- endmacro %}
+
+{%- macro toctree(docnames) -%}
+.. toctree::
+{% for docname in docnames %}
+  {{ docname }}
+{%- endfor %}
+{%- endmacro %}
+
+{{ pkgname.split(".")[-1] | e | heading }}
+
+.. code-block:: python
+
+  import {{ pkgname }}
+
+{%- if modulefirst and not is_namespace %}
+{{ automodule(pkgname, automodule_options) }}
+{% endif %}
+
+{%- if not modulefirst and not is_namespace %}
+
+{{ automodule(pkgname, automodule_options) }}
+{% endif %}
+
+{%- if submodules or subpackages %}
+.. rubric:: Submodules and Subpackages
+{% endif %}
+
+{%- if subpackages %}
+
+{{ toctree(subpackages) }}
+{% endif %}
+{%- if submodules %}
+{% if separatemodules %}
+{{ toctree(submodules) }}
+{%- else %}
+{%- for submodule in submodules %}
+{% if show_headings %}
+{{- [submodule, "module"] | join(" ") | e | heading(2) }}
+{% endif %}
+{{ automodule(submodule, automodule_options) }}
+{% endfor %}
+{%- endif %}
+{% endif %}

--- a/src/sphinx_api_relink/templates/toc.rst_t
+++ b/src/sphinx_api_relink/templates/toc.rst_t
@@ -1,0 +1,7 @@
+{{ header | heading }}
+
+.. toctree::
+  :maxdepth: {{ maxdepth }}
+{% for docname in docnames %}
+  {{ docname }}
+{%- endfor %}


### PR DESCRIPTION
This PR makes it possible to generate an API through [`sphinx.ext.autodoc`](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html) by adding this to your `conf.py`:

```python
api_package_path = "../src/my_package"  # relative to conf.py
```

More configuration values can be found in `README.md`.

The extension wraps legacy codes like [this](https://github.com/ComPWA/ampform/blob/908e2edb50c17c572c5c32b9f31047e2fd9f2f61/docs/conf.py#L100-L114).