### PR TITLE
FEAT: add `get_version()` function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 dependencies = [
     "Sphinx>=4.4",
     "docutils",
+    'importlib-metadata; python_version <"3.8.0"',
 ]
 description = "Relink type hints in your Sphinx API"
 dynamic = ["version"]

--- a/src/sphinx_api_relink/__init__.py
+++ b/src/sphinx_api_relink/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import shutil
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -12,9 +13,20 @@ from sphinx.addnodes import pending_xref, pending_xref_condition
 from sphinx.domains.python import parse_reftarget
 from sphinx.ext.apidoc import main as sphinx_apidoc
 
+if sys.version_info < (3, 8):
+    from importlib_metadata import version
+else:
+    from importlib.metadata import version
+
 if TYPE_CHECKING:
     from sphinx.application import Sphinx
     from sphinx.environment import BuildEnvironment
+
+
+def get_version(package_name: str) -> str:
+    """Get the version (MAJOR.MINOR.PATCH) of a Python package."""
+    v = version(package_name)
+    return ".".join(v.split(".")[:3])
 
 
 def setup(app: Sphinx) -> dict[str, Any]:


### PR DESCRIPTION
Added a small function, `get_version()`, that can be used in your `conf.py` file to set the version for your API, e.g.:

```python
from sphinx_api_relink import get_version

PACKAGE_NAME = "my-package"
release = get_version(PACKAGE_NAME)
version = get_version(PACKAGE_NAME)
```