### PR TITLE
BREAK: move to `helpers.get_package_version()`

### DIFF
--- a/src/sphinx_api_relink/__init__.py
+++ b/src/sphinx_api_relink/__init__.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import shutil
-import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -11,20 +10,9 @@ from sphinx.addnodes import pending_xref, pending_xref_condition
 from sphinx.domains.python import parse_reftarget
 from sphinx.ext.apidoc import main as sphinx_apidoc
 
-if sys.version_info < (3, 8):
-    from importlib_metadata import version
-else:
-    from importlib.metadata import version
-
 if TYPE_CHECKING:
     from sphinx.application import Sphinx
     from sphinx.environment import BuildEnvironment
-
-
-def get_version(package_name: str) -> str:
-    """Get the version (MAJOR.MINOR.PATCH) of a Python package."""
-    v = version(package_name)
-    return ".".join(v.split(".")[:3])
 
 
 def setup(app: Sphinx) -> dict[str, Any]:

--- a/src/sphinx_api_relink/helpers.py
+++ b/src/sphinx_api_relink/helpers.py
@@ -7,6 +7,11 @@ import os
 import re
 import sys
 
+if sys.version_info < (3, 8):
+    from importlib_metadata import version
+else:
+    from importlib.metadata import version
+
 __VERSION_REMAPPING: dict[str, dict[str, str]] = {}
 
 
@@ -30,6 +35,12 @@ def get_execution_mode() -> str:
     if "EXECUTE_NB" in os.environ:
         return "cache"
     return "off"
+
+
+def get_package_version(package_name: str) -> str:
+    """Get the version (MAJOR.MINOR.PATCH) of a Python package."""
+    v = version(package_name)
+    return ".".join(v.split(".")[:3])
 
 
 def pin(


### PR DESCRIPTION
Rename `sphinx_api_relink.get_version()` to `sphinx_api_relink.helpers.get_package_version()`.