### PR TITLE
ENH: activate `linkcode` only if `api_github_repo`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ api_target_types: dict[str, str] = {
 }
 ```
 
-The extension also links to the source code on GitHub through the [`sphinx.ext.linkcode`](https://www.sphinx-doc.org/en/master/usage/extensions/linkcode.html) extension. You need to specify the GitHub organization and the repository name as follows:
+The extension can also link to the source code on GitHub through the [`sphinx.ext.linkcode`](https://www.sphinx-doc.org/en/master/usage/extensions/linkcode.html) extension. To activate, specify the GitHub organization and the repository name as follows:
 
 ```
 api_github_repo: str = "ComPWA/sphinx-api-relink"

--- a/src/sphinx_api_relink/__init__.py
+++ b/src/sphinx_api_relink/__init__.py
@@ -29,7 +29,6 @@ def setup(app: Sphinx) -> dict[str, Any]:
     app.connect("config-inited", set_linkcode_resolve)
     app.connect("config-inited", generate_apidoc)
     app.connect("config-inited", replace_type_to_xref)
-    app.setup_extension("sphinx.ext.linkcode")
     return {
         "parallel_read_safe": True,
         "parallel_write_safe": True,
@@ -39,13 +38,10 @@ def setup(app: Sphinx) -> dict[str, Any]:
 def set_linkcode_resolve(app: Sphinx, _: BuildEnvironment) -> None:
     github_repo: str | None = app.config.api_github_repo
     if github_repo is None:
-        msg = (
-            "Please set api_github_repo in conf.py, e.g. api_github_repo ="
-            ' "ComPWA/sphinx-api-relink"'
-        )
-        raise ValueError(msg)
+        return
     debug: bool = app.config.api_linkcode_debug
     app.config.linkcode_resolve = get_linkcode_resolve(github_repo, debug)  # type: ignore[attr-defined]
+    app.setup_extension("sphinx.ext.linkcode")
 
 
 def generate_apidoc(app: Sphinx, _: BuildEnvironment) -> None:


### PR DESCRIPTION
The [`sphinx.ext.linkcode`](https://www.sphinx-doc.org/en/master/usage/extensions/linkcode.html) extension is now only activated if `api_github_repo` is specified.